### PR TITLE
Implement progress callback

### DIFF
--- a/seoparser/gui.py
+++ b/seoparser/gui.py
@@ -97,6 +97,10 @@ class MainWindow(QWidget):
     def log_message(self, msg: str):
         self.log.appendPlainText(msg)
 
+    def on_progress(self, current: int, total: int):
+        percent = int(current / total * 100) if total else 0
+        self.progress.setValue(percent)
+
     def export_results(self):
         path, _ = QFileDialog.getSaveFileName(self, "Save", "results.csv", "CSV (*.csv)")
         if not path:
@@ -108,7 +112,7 @@ class MainWindow(QWidget):
         url = self.url_edit.text().strip()
         if not url:
             return
-        self.crawler = SEOCrawler(url)
+        self.crawler = SEOCrawler(url, progress_callback=self.on_progress)
         self.table_model._data = self.crawler.results
         self.table_model.update()
         self.progress.setValue(0)


### PR DESCRIPTION
## Summary
- add `progress_callback` argument in crawler
- invoke callback after each processed page
- hook progress callback to GUI to update progress bar

## Testing
- `python -m compileall -q seoparser`

------
https://chatgpt.com/codex/tasks/task_e_6854dbd70cf083309e1ccf1a5a768d2a