### PR TITLE
Update README with PyQt5 system deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Simple SEO crawler with PyQt5 interface.
 - pandas
 - openpyxl
 
+## System Packages for PyQt5 on Linux
+PyQt5 depends on system libraries that may not be installed by default on Linux.
+Install them with `apt`:
+
+```bash
+sudo apt-get update
+sudo apt-get install libgl1
+```
+
+If `libGL.so.1` is missing, the GUI will fail to start until the package above is
+installed.
+
 ## Usage
 Install requirements:
 ```bash


### PR DESCRIPTION
## Summary
- document PyQt5 system package installation on Linux
- warn about missing `libGL.so.1`

## Testing
- `pip install -r requirements.txt`
- `python -m seoparser` *(fails: Could not load the Qt platform plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6854dbc8531c8330a9255dbb6426bebc